### PR TITLE
fix GitHub link

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -16,7 +16,7 @@ monofontoptions: "Scale=0.7"
 site: bookdown::bookdown_site
 description: "A guide to computationa genomics using R. The book covers fundemental topics with practical examples for an interdisciplinery audience"
 url: 'https\://compmgenomr.github.io/book/'
-github-repo: compgenomr/bookdown
+github-repo: compgenomr/book
 cover-image: images/cover.jpg
 ---
 


### PR DESCRIPTION
fixing the Github link (top-right).
- was pointing to https://github.com/compgenomr/bookdown
- now pointing to https://github.com/compgenomr/book