### PR TITLE
Typo in chapter 1.2.1

### DIFF
--- a/01-intro2Genomics.Rmd
+++ b/01-intro2Genomics.Rmd
@@ -208,7 +208,7 @@ altered protein-protein interactions.
 ####   Regulation by transcription factors through regulatory regions
  Transcripton factors are proteins that
 recognize a specific DNA motif to bind on a regulatory region and regulate the transcription rate of
-the gene associated with that regulatory region (See Figure \@ref(fig:regSummary))`
+the gene associated with that regulatory region (See Figure \@ref(fig:regSummary)
 for an illustration). These factors bind to a variety of regulatory regions summarized in
 Figure \@ref(fig:regSummary), and their concerted action
 controls the transcription rate. Apart from their binding preference, their


### PR DESCRIPTION
A parenthesis was closed twice and a " ' " was placed in the wrong location